### PR TITLE
Updating package name

### DIFF
--- a/mac
+++ b/mac
@@ -113,7 +113,7 @@ brew bundle --file=- <<EOF
 tap "thoughtbot/formulae"
 tap "homebrew/services"
 tap "universal-ctags/universal-ctags"
-tap "caskroom/cask"
+tap "homebrew/cask"
 
 # Unix
 brew "universal-ctags", args: ["HEAD"]


### PR DESCRIPTION
caskroom/cask now tells you to use homebrew/cask.

It may be worth pulling in all the changes from the upstream of this fork.