### PR TITLE
Update locations of packages that have been moved or renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,12 @@ the script each time on a fresh install thats ready to go.
 
 [UTM]: https://mac.getutm.app
 
+Spinning up a VM can take a while, though, so a quicker way to test changes is to uninstall Homebrew completely and rerun this script:
+```sh
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"; sudo rm -rf /opt/homebrew/; sudo rm -rf ~/.asdf;
+sh mac 2>&1 | tee ~/laptop.log
+```
+
 License
 -------
 

--- a/mac
+++ b/mac
@@ -105,14 +105,11 @@ fi
 fancy_echo "Updating Homebrew formulae ..."
 brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
-tap "thoughtbot/formulae"
 tap "homebrew/services"
 tap "heroku/brew"
-tap "universal-ctags/universal-ctags"
-tap "homebrew/cask"
 
 # Unix
-brew "universal-ctags/universal-ctags/universal-ctags", args: ["HEAD"]
+brew "universal-ctags"
 brew "git"
 brew "openssl"
 brew "rcm"
@@ -125,7 +122,6 @@ brew "zsh"
 
 # Heroku
 brew "heroku/brew/heroku"
-brew "parity"
 
 # GitHub
 brew "gh"
@@ -143,7 +139,7 @@ brew "yarn"
 cask "gpg-suite-no-mail"
 
 # Databases
-brew "postgresql", restart_service: :changed
+brew "postgresql@14", restart_service: :changed
 brew "redis", restart_service: :changed
 EOF
 
@@ -190,6 +186,9 @@ install_asdf_language "ruby"
 gem update --system
 number_of_cores=$(sysctl -n hw.ncpu)
 bundle config --global jobs $((number_of_cores - 1))
+
+fancy_echo "Installing ruby packages ..."
+gem install parity
 
 fancy_echo "Installing latest Node ..."
 install_asdf_language "nodejs"


### PR DESCRIPTION
After running the laptop script, a few warnings and errors cropped up:
```
Warning: Formula universal-ctags/universal-ctags/universal-ctags was renamed to universal-ctags.
Warning: 'universal-ctags/universal-ctags/universal-ctags' formula is unreadable: No available formula with the name "homebrew/core/universal-ctags".
Please tap it and then try again: brew tap homebrew/core
Error: Tapping homebrew/cask is no longer typically necessary.
Add --force if you are sure you need it for contributing to Homebrew.
Tapping homebrew/cask has failed!
Installing universal-ctags/universal-ctags/universal-ctags
Warning: Formula universal-ctags/universal-ctags/universal-ctags was renamed to universal-ctags.
Warning: No available formula with the name "homebrew/core/universal-ctags".
Warning: 'parity' formula is unreadable: No available formula with the name "parity". Did you mean pari?
Warning: 'parity' formula is unreadable: No available formula with the name "parity". Did you mean pari?
Warning: Formula postgresql was renamed to postgresql@14.
```

The `universal-ctags` and `postgresql` formulas just needed to be renamed, but the `parity` formula didn't seem to exist anymore. I tracked down the missing formula to [this PR on the parity repo](https://github.com/thoughtbot/parity/pull/191), which cites a removed dependency as the reason for moving `parity` over to a gem-based install method. I added this in and removed the thoughtbot formula tap as it was no longer needed.

To test these changes I needed a way to undo the changes added by the script - I couldn't do exactly that, but I figured a usable proxy would be to remove homebrew and asdf before rerunning the script. I did so with the following command:
```
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"; sudo rm -rf /opt/homebrew/; sudo rm -rf ~/.asdf;
```
I also added this to the README for future contributors.